### PR TITLE
Inotify::read_events handles only a buffer's worth of events.

### DIFF
--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -295,12 +295,12 @@ impl Inotify {
         result
     }
 
-    /// Returns any available events
+    /// Returns one buffer's worth of available events
     ///
-    /// Returns an iterator over all events that are currently available. If no
-    /// events are available, an iterator is still returned. If you need a
-    /// method that will block until at least one event is available, please
-    /// consider [`read_events_blocking`].
+    /// Reads as many events as possible into `buffer`, and returns an iterator
+    /// over them. If no events are available, an iterator is still returned. If
+    /// you need a method that will block until at least one event is available,
+    /// please consider [`read_events_blocking`].
     ///
     /// Please note that inotify will merge identical unread events into a
     /// single event. This means this method can not be used to count the number


### PR DESCRIPTION
Change the documentation of `Inotify::read_events` to match the actual behavior:
return an iterator over only as many events can fit in the supplied buffer, not
over any available events. Since this is a backwards-incompatible change, bump
the crate version number to 0.9.0.

It would be possible to make `Events` behave as documented, but it would need to
hold a strong reference to `fd` and a mutable reference to `buffer`, and it
seems awkward. The `notify` crate's use of `read_events` is easily switched by
requesting level-sensitive notification on the inotify file descriptor, which is
designed for exactly this sort of situation.