### PR TITLE
Clarify deduplication section in the read_event docs

### DIFF
--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -302,9 +302,9 @@ impl Inotify {
     /// you need a method that will block until at least one event is available,
     /// please consider [`read_events_blocking`].
     ///
-    /// Please note that inotify will merge identical unread events into a
-    /// single event. This means this method can not be used to count the number
-    /// of file system events.
+    /// Please note that inotify will merge identical successive unread events 
+    /// into a single event. This means this method can not be used to count the 
+    /// number of file system events.
     ///
     /// The `buffer` argument, as the name indicates, is used as a buffer for
     /// the inotify events. Its contents may be overwritten.


### PR DESCRIPTION
Non consecutive events aren't deduplicated, so we can't for example rely on deduplication to avoid the buffer overflowing when watching a known number of files.

https://man7.org/linux/man-pages/man7/inotify.7.html